### PR TITLE
Fix compose paths

### DIFF
--- a/hagelskott-analys/docker/docker-compose.yml
+++ b/hagelskott-analys/docker/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   mongodb:
     image: mongo:latest
@@ -10,12 +8,12 @@ services:
 
   backend:
     build:
-      context: ./backend
+      context: ../backend
       dockerfile: ../docker/backend.Dockerfile
     ports:
       - "8000:8000"
     volumes:
-      - ./backend:/app
+      - ../backend:/app
     environment:
       - MONGODB_URL=mongodb://mongodb:27017
     depends_on:
@@ -23,12 +21,12 @@ services:
 
   frontend:
     build:
-      context: ./frontend
+      context: ../frontend
       dockerfile: ../docker/frontend.Dockerfile
     ports:
       - "5173:5173"
     volumes:
-      - ./frontend:/app
+      - ../frontend:/app
     depends_on:
       - backend
 


### PR DESCRIPTION
## Summary
- update compose paths for backend and frontend services
- remove version key to silence docker warning

## Testing
- `docker-compose config` *(fails: command not found)*